### PR TITLE
Restrict lib-tao-qti to QTI-SDK 0.9.x.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 	],
 	"require" : {
 		"php" : ">=5.3.10",
-		"qtism/qtism":"~0.9",
+		"qtism/qtism":"~0.9.0",
         "oat-sa/lib-beeme": "0.0.0"
 	},
 	"require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
 	"name": "oat-sa/lib-tao-qti",
 	"description": "QTI Software Module Library for TAO",
-	"version": "0.9.0",
 	"type": "library",
 	"authors": [
 		{


### PR DESCRIPTION
The idea is to restrict the use of QTI-SDK 0.9.x in lib-tao-qti. In the (very next) future, we would like to develop a QTI-SDK 0.10.x for TAO, to be integrated gradually across vendor specific projects.

Moreover, this enables us to begin the tagging process on lib-tao-qti.