### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     ],
     "require" : {
         "php" : ">=5.3.10",
-        "qtism/qtism":"~0.10.3",
+        "qtism/qtism":"~0.10.4",
         "oat-sa/lib-beeme": "~0.0.0"
     },
     "require-dev": {


### PR DESCRIPTION
Must depends on QTI SDK 0.10.4 minimum, in order to get essential fixes live.