### PR TITLE
Reference exact qtisdk legacy version to avoid issues.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     ],
     "require" : {
         "php" : ">=5.3.10",
-        "qtism/qtism":"~0.10.21",
+        "qtism/qtism":"0.10.22",
         "oat-sa/lib-beeme": "~0.0.0"
     },
     "require-dev": {


### PR DESCRIPTION
@antoinerobin If released as 2.1.1, will make its way automatically to local repos !