### PR TITLE
Feature/ms 59/external scoring

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     ],
     "require" : {
         "php" : ">=5.3.10",
-        "qtism/qtism":"dev-feature/MS-59/external-scoring",
+        "qtism/qtism":"0.19.0",
         "oat-sa/lib-beeme": "~0.0.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     ],
     "require" : {
         "php" : ">=5.3.10",
-        "qtism/qtism":"0.18.0",
+        "qtism/qtism":"dev-feature/MS-59/external-scoring",
         "oat-sa/lib-beeme": "~0.0.0"
     },
     "require-dev": {


### PR DESCRIPTION
Upgraded QTI-SDK to legacy version 0.19.0:

This version adds support for:

- QTI 2.2 `externalScored` attribute in outcome declaration.

- PHP 7.4:
    - Code in the form of `a ? b : c ? d : e` without proper parentheses is deprecated and will break in the next version of PHP
    - Accessing `null` as an array does not return `null` any more. `?? null` has been added in Json marshaller.

- Travis execution of all tests (PHP 7.0 to 7.4).

Support for PHP < 7.0 is dropped.
