### PR TITLE
Dropped support for PHP < 7.0.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "GPL-2.0-only"
     ],
     "require" : {
-        "php" : ">=5.3.10",
+        "php" : "~7.0",
         "qtism/qtism":"0.19.0",
         "oat-sa/lib-beeme": "~0.0.0"
     },


### PR DESCRIPTION
QTI-SDK 0.19.0 dropped support for PHP < 7.0.