### PR TITLE
UDI-26: Lift a strict restriction on dependencies versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     ],
     "require" : {
         "php" : "~7.0",
-        "qtism/qtism": "^0.19",
+        "qtism/qtism": "~0.19",
         "oat-sa/lib-beeme": "~0.0.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     ],
     "require" : {
         "php" : "~7.0",
-        "qtism/qtism":"0.19.0",
+        "qtism/qtism": "^0.19",
         "oat-sa/lib-beeme": "~0.0.0"
     },
     "require-dev": {


### PR DESCRIPTION
- UDI-26 chore(dependencies): allow minor upgrades of `qtism/qtism` in end applications