### PR TITLE
Feature TCA-666 Aria Attributes Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     ],
     "require" : {
         "php" : "~7.0",
-        "qtism/qtism": "0.19.4",
+        "qtism/qtism": "dev-feature/tca-666/aria-attributes-legacy",
         "oat-sa/lib-beeme": "~0.0.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "oat-sa/lib-beeme": "~0.0.0"
     },
     "require-dev": {
-        "phpunit/PHPUnit": "<6.0.0"
+        "phpunit/phpunit": "<6.0.0"
     },
     "autoload": {
         "classmap": ["helpers/"],

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     ],
     "require" : {
         "php" : "~7.0",
-        "qtism/qtism": "dev-feature/tca-666/aria-attributes-legacy",
+        "qtism/qtism": "0.21.0",
         "oat-sa/lib-beeme": "~0.0.0"
     },
     "require-dev": {


### PR DESCRIPTION
This Pull Request aims at providing Integration Testing of the future `0.21.0` release of QTI-SDK. As soon as the Integration Testing is done by QA, the following line in the `composer.json` file.

```json
...
"qtism/qtism": "dev-feature/tca-666/aria-attributes-legacy",
...
```

must be replaced with

```json
...
"qtism/qtism": "0.21.0",
...
```

**Please pay attention that the Integration Testing of QTI-SDK `0.20.0` is still on hold. We need to push on this first,** and then get another round for `0.21.0`. Please see [QI-316](https://oat-sa.atlassian.net/browse/QI-316).

Finally, merging this PR must result in the release `5.2.0` of `lib-tao-qti`.

**This PR is a companion PR of:**

* https://github.com/oat-sa/qti-sdk/pull/198
* https://github.com/oat-sa/extension-tao-itemqti/pull/1483
