### PR TITLE
Upgraded QTI-SDK legacy to 0.22.1.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     ],
     "require" : {
         "php" : "~7.0",
-        "qtism/qtism": "0.22.0",
+        "qtism/qtism": "0.22.1",
         "oat-sa/lib-beeme": "~0.0.0"
     },
     "require-dev": {


### PR DESCRIPTION
This PR includes QTI-SDK 0.22.1 for ellipse collision detection fix.
See https://github.com/oat-sa/qti-sdk/pull/217 for more details.