### PR TITLE
Changed lib-beeme version constraint to get latest version below breaking change.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require" : {
         "php" : "~7.0",
         "qtism/qtism": "0.22.1",
-        "oat-sa/lib-beeme": "~0.0.0"
+        "oat-sa/lib-beeme": "^0.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "<6.0.0"


### PR DESCRIPTION
Changed version constraint from ~0.0.0 (equivalent to >=0.0.0 & <0.1.0) to ^0.0.0 (equivalent to >=0.0.0 & <1.0.0) to get the latest version below breaking change