### PR TITLE
Upgraded QTI-SDK legacy to 0.22.3.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     ],
     "require" : {
         "php" : "~7.0",
-        "qtism/qtism": "0.22.1",
+        "qtism/qtism": "0.22.3",
         "oat-sa/lib-beeme": "^0.0.0"
     },
     "require-dev": {


### PR DESCRIPTION
This PR includes two upgrades of QTI-SDK:
- 0.22.2: Fixed implementation of expectedLength and expectedLines for ExtendedTextInteraction and TextEntryInteraction
- 0.22.3: Added LIBXML_BIGLINES flag to allow XML parser to deal with line numbers greater then 65535
