### PR TITLE
Upgraded QTI-SDK legacy to 0.22.4.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     ],
     "require" : {
         "php" : "~7.0",
-        "qtism/qtism": "0.22.3",
+        "qtism/qtism": "0.22.4",
         "oat-sa/lib-beeme": "0.2.0"
     },
     "require-dev": {


### PR DESCRIPTION
This PR includes one upgrade of QTI-SDK:
- Support for storage of a hash of an uploaded file instead of the content of the file itself, to avoid huge payloads to be stored in the test session. Please read https://github.com/oat-sa/qti-sdk/pull/227 description for more details and usage example.