### PR TITLE
Support for Php 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,11 +30,11 @@
         "GPL-2.0-only"
     ],
     "require" : {
-        "php" : "~7.0",
-        "qtism/qtism": "0.22.5"
+        "php" : ">=7.1",
+        "qtism/qtism": "0.23.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "<6.0.0"
+        "phpunit/phpunit": "<9.0.0"
     },
     "autoload": {
         "classmap": ["helpers/"]

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,7 +2,6 @@
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
          bootstrap="./vendor/autoload.php"
-         strict="true"
          verbose="true">
  <testsuites>
   <testsuite name="lib qti">

--- a/test/LegacyStateOutputTest.php
+++ b/test/LegacyStateOutputTest.php
@@ -105,7 +105,7 @@ class LegacyStateOutputTest extends TestCase
         $sO->addVariable(new OutcomeVariable('OUT3', Cardinality::ORDERED, BaseType::FLOAT, null));
     
         $expectedArray = array();
-        $expectedArray['RESP1'] = array('0.0');
+        $expectedArray['RESP1'] = array('0');
         $expectedArray['RESP2'] = array('-13.65', '1337.1');
         $expectedArray['OUT1'] = array();
         $expectedArray['OUT2'] = array('', '-466.3');

--- a/test/LegacyStateOutputTest.php
+++ b/test/LegacyStateOutputTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use qtism\common\datatypes\QtiDuration;
 use qtism\common\datatypes\QtiPair;
 use qtism\common\datatypes\QtiDirectedPair;
@@ -45,8 +46,8 @@ use qtism\runtime\common\ResponseVariable;
  * @package taoQtiCommon
  
  */
-class LegacyStateOutputTest extends  PHPUnit_Framework_TestCase{
-	
+class LegacyStateOutputTest extends TestCase
+{
     public function testStateOutputIdentifier() {
         $sO = new taoQtiCommon_helpers_LegacyStateOutput();
         $sO->addVariable(new ResponseVariable('RESP1', Cardinality::SINGLE, BaseType::IDENTIFIER, new QtiIdentifier('ChoiceA')));

--- a/test/PciJsonMarshallerTest.php
+++ b/test/PciJsonMarshallerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use qtism\common\datatypes\QtiFile;
 use qtism\common\datatypes\files\FileSystemFileManager;
 
@@ -30,11 +31,12 @@ use qtism\common\datatypes\files\FileSystemFileManager;
  * @package taoQtiCommon
  * @subpackage test
  */
-class PciJsonMarshallerTest extends PHPUnit_Framework_TestCase {
-	
+class PciJsonMarshallerTest extends TestCase
+{
     private $file;
     
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
         
         $fileManager = new FileSystemFileManager();
@@ -42,7 +44,8 @@ class PciJsonMarshallerTest extends PHPUnit_Framework_TestCase {
         $this->setFile($file);
     }
     
-    public function tearDown() {
+    public function tearDown(): void
+    {
         parent::tearDown();
         
         $fileManager = new FileSystemFileManager();

--- a/test/PciStateOutputTest.php
+++ b/test/PciStateOutputTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use qtism\runtime\common\Variable;
+use PHPUnit\Framework\TestCase;
 use qtism\runtime\common\MultipleContainer;
 use qtism\runtime\common\OrderedContainer;
 use qtism\runtime\common\RecordContainer;
@@ -47,8 +47,8 @@ use qtism\common\enums\BaseType;
  * @package taoQtiCommon
  
  */
-class PciStateOutputTest extends PHPUnit_Framework_TestCase {
-	
+class PciStateOutputTest extends TestCase
+{
     public function testStateOutputIdentifier() {
         $sO = new taoQtiCommon_helpers_PciStateOutput();
         $sO->addVariable(new ResponseVariable('RESP1', Cardinality::SINGLE, BaseType::IDENTIFIER, new QtiIdentifier('ChoiceA')));

--- a/test/PciVariableFillerTest.php
+++ b/test/PciVariableFillerTest.php
@@ -19,7 +19,7 @@
  * 
  */
 
-
+use PHPUnit\Framework\TestCase;
 use qtism\runtime\common\Variable;
 use qtism\runtime\common\ResponseVariable;
 use qtism\runtime\common\OutcomeVariable;
@@ -52,8 +52,8 @@ use qtism\common\datatypes\QtiIntOrIdentifier;
  * @package taoQtiCommon
  
  */
-class PciVariableFillerTest extends PHPUnit_Framework_TestCase {
-	
+class PciVariableFillerTest extends TestCase
+{
     /**
      * @dataProvider fillVariableProvider
      * 

--- a/test/UtilsTest.php
+++ b/test/UtilsTest.php
@@ -18,6 +18,7 @@
  *               
  */
 
+use PHPUnit\Framework\TestCase;
 use qtism\common\datatypes\QtiDatatype;
 use qtism\common\datatypes\QtiIdentifier;
 use qtism\common\datatypes\QtiPair;
@@ -27,8 +28,8 @@ use qtism\common\enums\BaseType;
 use qtism\runtime\common\MultipleContainer;
 use qtism\runtime\common\OrderedContainer;
 
-class UtilsTest extends PHPUnit_Framework_TestCase {
-	
+class UtilsTest extends TestCase
+{
     /**
      * @dataProvider toQtiDatatypeProvider
      */


### PR DESCRIPTION
This PR **adds support for PHP 8.0** and **drops support for PHP 7.0**.

See https://github.com/oat-sa/qti-sdk/pull/243 for further details on the PHP and PhpUnit version choice.
