### PR TITLE
Fixed PHP 7 Match operator support.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "require" : {
         "php" : ">=7.1",
-        "qtism/qtism": "0.24.0"
+        "qtism/qtism": "0.24.1"
     },
     "require-dev": {
         "phpunit/phpunit": "<9.0.0"


### PR DESCRIPTION
In PHP 8.*, `match` is a reserved word, the Match operator class has been renamed `MatchOperator` but former Tao compiled tests still contain generated PHP code with references to the `Match` class.

This PR makes sure these compiled tests still run in PHP 7.*.
However, when run on PHP 8.0, the older compiled tests containing usages of the `Match` class will have to be updated either by re-publishing or by running a script to update the generated PHP code.