### PR TITLE
Upgraded QTI-SDK to 0.24.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "require" : {
         "php" : ">=7.1",
-        "qtism/qtism": "0.24.3"
+        "qtism/qtism": "0.24.4"
     },
     "require-dev": {
         "phpunit/phpunit": "<9.0.0"


### PR DESCRIPTION
Fixed minChoices in HottextInteraction and PositionObjectInteraction to be valid when greater than maxChoices if and only if the latter is 0.