### PR TITLE
Merge for release 7.2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "require" : {
         "php" : ">=7.1",
-        "qtism/qtism": "0.24.11"
+        "qtism/qtism": "0.24.12"
     },
     "require-dev": {
         "phpunit/phpunit": "<9.0.0"

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "require" : {
         "php" : ">=7.1",
-        "qtism/qtism": "0.24.10"
+        "qtism/qtism": "0.24.11"
     },
     "require-dev": {
         "phpunit/phpunit": "<9.0.0"


### PR DESCRIPTION
Upgrade `qti-sdk` to `0.24.12`, introducing precondition rules are checked on all test parts, sections and items, not only on first item in section.