### PR TITLE
fix: include QTI-SDK legacy 0.24.12 for TR-1648

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     ],
     "require" : {
         "php" : "~7.0",
-        "qtism/qtism": "0.21.0",
+        "qtism/qtism": "0.24.12",
         "oat-sa/lib-beeme": "~0.0.0"
     },
     "require-dev": {


### PR DESCRIPTION
Include QTI-SDK legacy 0.24.12 for TR-1648