### PR TITLE
chore(version): require qtism/qtism v0.25.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "require" : {
         "php" : ">=7.1",
-        "qtism/qtism": "0.24.13"
+        "qtism/qtism": "0.25.0"
     },
     "require-dev": {
         "phpunit/phpunit": "<9.0.0"


### PR DESCRIPTION
# [TR-1351](https://oat-sa.atlassian.net/browse/TR-1351)

- Support of 'list' type in a record, fix incorrect response in case of 'list' types
