### PR TITLE
fix: require `qtism/qtism` `v0.25.1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "require" : {
         "php" : ">=7.1",
-        "qtism/qtism": "0.25.0"
+        "qtism/qtism": "0.25.1"
     },
     "require-dev": {
         "phpunit/phpunit": "<9.0.0"


### PR DESCRIPTION
## [TR-2459](https://oat-sa.atlassian.net/browse/TR-2459)

- fix: unify acceptable latency influence on `mmove` and `jump` behavior