### PR TITLE
feat: require qti-sdk 0.26

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "require" : {
         "php" : ">=7.1",
-        "qtism/qtism": "dev-feature/legacy/TR-1499/support_qti_figure_figcaption_elements as 0.25.1"
+        "qtism/qtism": "dev-feature/legacy/TR-1499/support_qti_figure_figcaption_elements as 0.25.2"
     },
     "require-dev": {
         "phpunit/phpunit": "<9.0.0"

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "require" : {
         "php" : ">=7.1",
-        "qtism/qtism": "dev-feature/legacy/TR-1499/support_qti_figure_figcaption_elements as 0.25.2"
+        "qtism/qtism": "0.26"
     },
     "require-dev": {
         "phpunit/phpunit": "<9.0.0"

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "require" : {
         "php" : ">=7.1",
-        "qtism/qtism": " 0.25.2"
+        "qtism/qtism": "dev-feature/legacy/TR-1499/support_qti_figure_figcaption_elements as 0.25.1"
     },
     "require-dev": {
         "phpunit/phpunit": "<9.0.0"


### PR DESCRIPTION
Required QTI SDK 0.26 version including feature: https://github.com/oat-sa/qti-sdk/pull/313