### PR TITLE
chore: update qtism version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "require" : {
         "php" : ">=7.1",
-        "qtism/qtism": "dev-feature/AUT-2337/marshall-lang-dir-attributes as 0.26.1"
+        "qtism/qtism": "0.26.1"
     },
     "require-dev": {
         "phpunit/phpunit": "<9.0.0"

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "require" : {
         "php" : ">=7.1",
-        "qtism/qtism": "0.26.1"
+        "qtism/qtism": "dev-feature/AUT-2337/marshall-lang-dir-attributes as 0.26.1"
     },
     "require-dev": {
         "phpunit/phpunit": "<9.0.0"

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "require" : {
         "php" : ">=7.1",
-        "qtism/qtism": "dev-feature/AUT-2337/marshall-lang-dir-attributes as 0.27.0"
+        "qtism/qtism": "dev-feature/AUT-2337/marshall-lang-dir-attributes as 0.26.1"
     },
     "require-dev": {
         "phpunit/phpunit": "<9.0.0"

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "require" : {
         "php" : ">=7.1",
-        "qtism/qtism": "0.26.1"
+        "qtism/qtism": "dev-feature/AUT-2337/marshall-lang-dir-attributes as 0.27.0"
     },
     "require-dev": {
         "phpunit/phpunit": "<9.0.0"

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "require" : {
         "php" : ">=7.1",
-        "qtism/qtism": "dev-feature/AUT-2337/marshall-lang-dir-attributes as 0.26.1"
+        "qtism/qtism": "0.27.0"
     },
     "require-dev": {
         "phpunit/phpunit": "<9.0.0"


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/AUT-2337

## Problem to solve

Import/export shared stimulus and keep the "lang" and "dir" attributes is not working.

Example where the problem happens: https://github.com/oat-sa/extension-tao-mediamanager/blob/master/model/sharedStimulus/encoder/SharedStimulusMediaEncoder.php#L51 When we call XmlDocument::load() it does not keep the attributes we need. 

## Solutions

- Add possibilities for custom attributes in the BodyElement

## PRs

- https://github.com/oat-sa/qti-sdk/pull/318
- https://github.com/oat-sa/extension-tao-itemqti/pull/2162