### PR TITLE
chore: update using last change to PHP 8.1 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "require" : {
         "php" : ">=7.1",
-        "qtism/qtism": "0.27.0"
+        "qtism/qtism": "dev-feature/TR-4391/ensure_qti_sdk_php_8_support_legacy as 0.27.0"
     },
     "require-dev": {
         "phpunit/phpunit": "<9.0.0"


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-1097
https://oat-sa.atlassian.net/browse/ADF-1087
https://oat-sa.atlassian.net/browse/ADF-1105

## Goal 

Make the extension not dictating PHP version to easier our PHP maintenance, since the extension does not work in isolation and PHP version should be equally respected to all TAO extensions.