### PR TITLE
Fix/TR-4212/Decode HTML entities in attributes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "require" : {
         "php" : ">=7.1",
-        "qtism/qtism": "0.28.0"
+        "qtism/qtism": "0.28.1"
     },
     "require-dev": {
         "phpunit/phpunit": "<9.0.0"


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-4212

Update QTI-SDK to version `0.28.1`.

Removes the double encoding of attributes (see https://github.com/oat-sa/qti-sdk/pull/325)