### PR TITLE
Release 7.7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "require" : {
         "php" : ">=7.1",
-        "qtism/qtism": "0.28.0"
+        "qtism/qtism": "0.28.1"
     },
     "require-dev": {
         "phpunit/phpunit": "<9.0.0"

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "require" : {
         "php" : ">=7.1",
-        "qtism/qtism": "0.27.0"
+        "qtism/qtism": "0.28.0"
     },
     "require-dev": {
         "phpunit/phpunit": "<9.0.0"


### PR DESCRIPTION
Update QTI-SDK to version `0.28.1`.

Removes the double encoding of attributes (see https://github.com/oat-sa/qti-sdk/pull/325)